### PR TITLE
Require a 7-Day Minimum Release Age for Dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
    sharp: true
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
    ],
    "rangeStrategy": "pin",
    "schedule": ["every weekend"],
-   "timezone": "America/Los_Angeles"
+   "timezone": "America/Los_Angeles",
+   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary
- Configure pnpm `minimumReleaseAge: 10080` (minutes = 7 days) in `pnpm-workspace.yaml` so direct installs refuse to pull versions younger than 7 days.
- Configure Renovate `minimumReleaseAge: "7 days"` in `renovate.json` so Renovate won't open PRs for fresh releases.
- Defense in depth against supply chain attacks (compromised maintainer credentials, malicious package versions) by giving the ecosystem time to spot and yank bad releases before they reach this repo.

## Test plan
- [x] `pnpm config get minimumReleaseAge` returns `10080`.
- [ ] Observe the next Renovate run: PRs should only appear for versions at least 7 days old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)